### PR TITLE
Update Next.js to the version 14.2.4 and others compatible dependencies

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,3 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  experimental: {
-    appDir: true,
-  },
-}
-
+const nextConfig = {}
 module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -9,24 +9,23 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@next/font": "13.1.6",
-    "@types/node": "18.11.18",
-    "@types/react": "18.0.27",
-    "@types/react-dom": "18.0.10",
-    "eslint": "8.32.0",
-    "eslint-config-next": "13.1.6",
-    "next": "13.1.6",
-    "next-themes": "^0.2.1",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "react-icons": "^4.7.1",
-    "react-scroll": "^1.8.9",
-    "typescript": "4.9.4"
+    "@types/node": "20.14.10",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "14.2.4",
+    "next": "14.2.4",
+    "next-themes": "^0.3.0",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "react-icons": "^5.2.1",
+    "react-scroll": "^1.9.0",
+    "typescript": "5.5.3"
   },
   "devDependencies": {
-    "@types/react-scroll": "^1.8.6",
-    "autoprefixer": "^10.4.13",
-    "postcss": "^8.4.21",
-    "tailwindcss": "^3.2.4"
+    "@types/react-scroll": "^1.8.10",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.39",
+    "tailwindcss": "^3.4.4"
   }
 }


### PR DESCRIPTION
Hello,

Here a PR to update Next.js to the version 14.2.4 and others compatible dependencies.

Notes: 
  - @next/font as been fully removed, cf [upgrade guide](https://nextjs.org/docs/app/building-your-application/upgrading/version-14)
  - eslint is still in version 8, as the version 9 is still incompatible https://github.com/vercel/next.js/issues/64409
   - remove the no longer needed "experimental appDir true" from the config
   
   Regards,